### PR TITLE
Support for windows was incomplete

### DIFF
--- a/rocket/connectors/socket.py
+++ b/rocket/connectors/socket.py
@@ -59,7 +59,10 @@ class SocketConnector(Connector):
     def greet_server(self):
         logger.info("Greeting server with: %s", CLIENT_GREET)
         self.writer.string(CLIENT_GREET)
-        data = self.reader.bytes(len(SERVER_GREET)).decode()
+        greet = self.reader.bytes(len(SERVER_GREET))
+        while greet is None:
+            greet = self.reader.bytes(len(SERVER_GREET))
+        data = greet.decode()
         logger.info("Server responded with: %s", data)
         if data != SERVER_GREET:
             raise ValueError("Invalid server response: {}".format(data))


### PR DESCRIPTION
Last PR by me was incomplete. New issue raised as socket communication on greeting was not blocking, so pyrocket failed to receive greetings back from rocket. As it assumed that greetings from rocket should be readable in instant. This PR waits in greeting as long as it is needed, i.e. it will continue only when pyrocket has received greetings back from rocket.